### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN/App Token [SEC-58]

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write # to create commits, tags, and releases
           permission-pull-requests: write # to create and update PRs
+          permission-members: read # to resolve team reviewers
 
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -79,11 +79,18 @@ jobs:
         id: finish-release
         run: |
           npm ci
-          npx standard-version -a --skip.tag
+          npx standard-version -a --skip.tag --skip.commit
 
-      - name: Push new version in release branch
-        run: |
-          git push
+      - name: Create verified commit via API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            CHANGELOG.md
+            gradle.properties
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -39,15 +39,8 @@ jobs:
         with:
           node-version: 16
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
-
       # Calculate the next release version based on conventional semantic release
-      - name: Create release branch
+      - name: Calculate release version
         id: create-release
         run: |
           source_branch_name=${GITHUB_REF##*/}
@@ -55,7 +48,7 @@ jobs:
           git fetch origin master --depth=1
           git merge origin/master
           current_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
-          
+
           npm ci
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
@@ -68,12 +61,20 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
+
+      - name: Create release branch via GitHub API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
 
       - name: Update changelog & bump version
         id: finish-release

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read # to read repository contents
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/')
@@ -19,9 +19,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set Node 16
@@ -80,7 +90,7 @@ jobs:
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body:  ":crown: *An automated PR*"
           pr_reviewer: 'itsdebs'

--- a/.github/workflows/notion_pr_sync.yml
+++ b/.github/workflows/notion_pr_sync.yml
@@ -46,6 +46,8 @@ on:
 jobs:
   request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -57,4 +59,4 @@ jobs:
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
-          githubKey: ${{ secrets.PAT }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: read # to read repository contents
     name: Publish new release
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' }} || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
@@ -21,6 +23,14 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -51,8 +61,8 @@ jobs:
       - name: Create GitHub Release & Tag
         id: create_release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
           git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -69,6 +69,9 @@ jobs:
           tag: 'v${{ steps.extract-version.outputs.release_version }}'
           files: ''
 
+      - name: Fetch remote tags
+        run: git fetch --tags
+
       - name: Create GitHub Release
         id: create_release
         env:

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -59,14 +59,22 @@ jobs:
         run: |
           git config user.name "GitHub actions"
           git config user.email noreply@github.com
-      - name: Create GitHub Release & Tag
+      - name: Create verified tag
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: master
+          commit-message: 'chore: release v${{ steps.extract-version.outputs.release_version }}'
+          tag: 'v${{ steps.extract-version.outputs.release_version }}'
+          files: ''
+
+      - name: Create GitHub Release
         id: create_release
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
-          git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular
       - name: Delete release branch
         uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master


### PR DESCRIPTION
## Summary
- Migrates all PAT usages to GITHUB_TOKEN or GitHub App Token
- Adds explicit permissions at job level with comments explaining why
- Uses signed commits via GitHub API for verified commits in release workflows
- **NEW: Simplified draft_new_release.yml to use GitHub API pattern**

### Files Changed
- .github/workflows/notion_pr_sync.yml (PAT -> GITHUB_TOKEN)
- .github/workflows/draft_new_release.yml (PAT -> App Token + signed commits + API pattern)
- .github/workflows/publish-new-github-release.yml (PAT -> App Token)

### Migration Details
| File | Token Type | Permissions | Change Made |
|------|------------|-------------|-------------|
| notion_pr_sync.yml | GITHUB_TOKEN | pull-requests: read | Added permissions, replaced PAT with GITHUB_TOKEN |
| draft_new_release.yml | App Token | contents: write, pull-requests: write | **Updated to use simplified GitHub API pattern** |
| publish-new-github-release.yml | App Token | contents: write | Added token generation, passes token to checkout for tag push |

### Migration Pattern Evolution

The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them. This eliminates the need for many git commands.

**Removed (no longer needed):**
- `git config user.name/email` steps - signed-commit uses App identity
- `git remote set-url` with token-in-URL - not needed with API
- `git push --set-upstream origin "$branch_name"` - replaced with API call
- `git push --follow-tags` - handled by signed-commit action

**Replaced with:**
- Create branch via GitHub API: `gh api repos/${{ github.repository }}/git/refs --method POST -f ref="refs/heads/$branch_name" -f sha="$BASE_SHA"`
- Use `--skip.commit --skip.tag` with standard-version
- Use `ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f` for commits

**Key Pattern:**
1. GitHub App token is generated early (actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4)
2. Calculate version locally without committing
3. Create branch via GitHub API
4. Run standard-version with --skip.commit --skip.tag to modify files on disk
5. Use signed-commit action to create verified commits via API

This approach produces verified commits while being cleaner and more secure than the token-in-URL pattern.

## Test plan
- [ ] Verify all workflows pass after merge
- [ ] Verify release commits show as "Verified" on GitHub
- [ ] Verify branch creation works via GitHub API

🤖 Generated with [Claude Code](https://claude.com/claude-code)